### PR TITLE
Move toolbar icon after select tool

### DIFF
--- a/HarmonicMove.glyphsTool/Contents/Resources/plugin.py
+++ b/HarmonicMove.glyphsTool/Contents/Resources/plugin.py
@@ -70,6 +70,7 @@ class HarmonicMove(SelectTool):
 	def settings(self):
 		self.name = Glyphs.localize({'en': u'Harmonic Move'})
 		self.keyboardShortcut = 'm'
+		self.toolbarPosition = 2
 
 	@objc.python_method
 	def start(self):


### PR DESCRIPTION
Since this tool behaves similar to the Select tool, I propose moving its icon next to the Select tool icon:

<img width="482" alt src="https://user-images.githubusercontent.com/3776198/174600402-d3c88989-8e57-46ef-bb54-08c31ce54112.png">
